### PR TITLE
Fix the `task reference is invalid` error for `ShowAsyncListitemIndexDialog`

### DIFF
--- a/tdialogs.inc
+++ b/tdialogs.inc
@@ -333,6 +333,7 @@ public TDialogs_DialogResponse(playerid, dialogid, response, listitem, inputtext
             }
 
             task_set_result(task, value);
+            return 1;
         }
         case TDIALOG_ID_STRING_INPUT, TDIALOG_ID_PASSWORD_INPUT, TDIALOG_ID_LISTITEM_TEXT:
         {
@@ -364,6 +365,7 @@ public TDialogs_DialogResponse(playerid, dialogid, response, listitem, inputtext
             }
 
             task_set_result(task, listitem);
+            return 1;
         }
         case TDIALOG_ID_CONFIRMATION:
         {


### PR DESCRIPTION
Cases `TDIALOG_ID_FLOAT_INPUT` and `TDIALOG_ID_LISTITEM_INDEX` were missing their return statements. This ensures correct dialog handling, preventing it from falling through to the default return 0.

The error showing up while using `ShowAsyncListitemIndexDialog_s`:
```
[2026-01-24T14:12:51+0100] [Info] [PawnPlus] Warning: amx_FindPublic returned negative index -10067 for function 'pp_on_error'. Possible collision with SAMPGDK detected. Use pp_public_min_index or pp_use_funcidx to remove this warning.
[2026-01-24T14:12:51+0100] [Info] [PawnPlus] task_set_result: task reference is invalid (value 0x0)
[2026-01-24T14:12:51+0100] [Error] Native function failed
```

